### PR TITLE
Removed colors completion status for exercise being state dependent

### DIFF
--- a/fytProject/components/containers/SetContainer.js
+++ b/fytProject/components/containers/SetContainer.js
@@ -40,21 +40,11 @@ class SetContainer extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      completionButtonColor: COLOR_2,
       modalVisible: false
     };
   }
 
   changeSetCompletionStatus = (exercise, setNumber) => {
-    if (this.state.completionButtonColor == COLOR_1) {
-      this.setState({
-        completionButtonColor: COLOR_2
-      });
-    } else {
-      this.setState({
-        completionButtonColor: COLOR_1
-      });
-    }
     this.props.changeSetCompletionStatus(
       exercise,
       setNumber,
@@ -98,15 +88,18 @@ class SetContainer extends React.Component {
               onPress={() =>
                 this.changeSetCompletionStatus(
                   this.props.exerciseName,
-                  this.props.setNumber,
-                  this.props.selectedWorkout
+                  this.props.setNumber
                 )
               }
             >
               <View
                 style={[
                   styles.circleButton,
-                  { backgroundColor: this.state.completionButtonColor }
+                  {
+                    backgroundColor: this.props.setDetails.completed
+                      ? COLOR_1
+                      : COLOR_2
+                  }
                 ]}
               >
                 <Text style={styles.circleButtonText}>


### PR DESCRIPTION
name: 🚀 Change the Exercise Panels so they get completion status from store not local state
about: Change the Exercise Panels so they get completion status from store not local state

Feature Request
Is your feature request related to a problem? Please describe.
Without getting completion status from store we run into the future issues of local state conflicting with the redux store on what is completed as if we filter(to order) the exercise cards the local state will bug out.

Describe the solution you'd like
None

Describe alternatives you've considered
None

Teachability, Documentation, Adoption, Migration Strategy
N/A more of a bug

Acceptance Tests
1.) Click a completion button in workout page
2.) See if it bugs out or displays obv unintended behavior